### PR TITLE
Added the following features

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>za.co.jumpingbean.jpaunit</groupId>
     <artifactId>JpaUnit</artifactId>
-    <version>0.1</version>
+    <version>0.2</version>
     <packaging>jar</packaging>
     <name>JPAUnit</name>
     <description>A library to assist with unit testing of JPA code by preloading 

--- a/src/main/java/za/co/jumpingbean/jpaunit/Utility.java
+++ b/src/main/java/za/co/jumpingbean/jpaunit/Utility.java
@@ -19,6 +19,7 @@
 package za.co.jumpingbean.jpaunit;
 
 import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
@@ -33,6 +34,16 @@ public interface Utility {
         Class currentClass = clazz;
         while (currentClass != Object.class) {
             fields.addAll(Arrays.asList(currentClass.getDeclaredFields()));
+            currentClass = currentClass.getSuperclass();
+        }
+        return fields;
+    }
+
+    static List<Method> getAllMethods(Class clazz) {
+        List<Method> fields = new LinkedList<>();
+        Class currentClass = clazz;
+        while (currentClass != Object.class) {
+            fields.addAll(Arrays.asList(currentClass.getDeclaredMethods()));
             currentClass = currentClass.getSuperclass();
         }
         return fields;

--- a/src/test/java/za/co/jumpingbean/jpaunit/test/AnnotatedFieldTest.java
+++ b/src/test/java/za/co/jumpingbean/jpaunit/test/AnnotatedFieldTest.java
@@ -1,0 +1,34 @@
+package za.co.jumpingbean.jpaunit.test;
+
+import org.junit.Assert;
+import org.junit.Test;
+import za.co.jumpingbean.jpaunit.JpaLoader;
+import za.co.jumpingbean.jpaunit.test.model.SimpleIntegerEntity;
+import za.co.jumpingbean.jpaunit.test.model.SubClassEntity;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.Optional;
+
+public class AnnotatedFieldTest {
+
+    JpaLoader jpaLoader = new JpaLoader();
+
+    @Test
+    public void testSimpleIntegerEntity() {
+        Optional<Field> optionalField = jpaLoader.getIdAnnotatedField(SimpleIntegerEntity.class);
+        Assert.assertTrue(optionalField.isPresent());
+    }
+
+    @Test
+    public void testAnnotatedMethod() {
+        Optional<Method> optionalMethod = jpaLoader.getIdAnnotatedMethod(SimpleIntegerEntity.class);
+        Assert.assertFalse(optionalMethod.isPresent());
+    }
+
+    @Test
+    public void testSubClassEntity() {
+        Optional<Field> optionalField = jpaLoader.getIdAnnotatedField(SubClassEntity.class);
+        Assert.assertTrue(optionalField.isPresent());
+    }
+}

--- a/src/test/java/za/co/jumpingbean/jpaunit/test/AnnotatedMethodTest.java
+++ b/src/test/java/za/co/jumpingbean/jpaunit/test/AnnotatedMethodTest.java
@@ -1,0 +1,27 @@
+package za.co.jumpingbean.jpaunit.test;
+
+import org.junit.Assert;
+import org.junit.Test;
+import za.co.jumpingbean.jpaunit.JpaLoader;
+import za.co.jumpingbean.jpaunit.test.model.AnnotatedIdMethodEntity;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.Optional;
+
+public class AnnotatedMethodTest {
+
+    JpaLoader jpaLoader = new JpaLoader();
+
+    @Test
+    public void testSimpleIntegerEntity() {
+        Optional<Field> optionalField = jpaLoader.getIdAnnotatedField(AnnotatedIdMethodEntity.class);
+        Assert.assertFalse(optionalField.isPresent());
+    }
+
+    @Test
+    public void testAnnotatedMethod() {
+        Optional<Method> optionalMethod = jpaLoader.getIdAnnotatedMethod(AnnotatedIdMethodEntity.class);
+        Assert.assertTrue(optionalMethod.isPresent());
+    }
+}

--- a/src/test/java/za/co/jumpingbean/jpaunit/test/JpaLoaderAnnotatedFieldEntityTest.java
+++ b/src/test/java/za/co/jumpingbean/jpaunit/test/JpaLoaderAnnotatedFieldEntityTest.java
@@ -1,0 +1,45 @@
+package za.co.jumpingbean.jpaunit.test;
+
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import za.co.jumpingbean.jpaunit.JpaLoader;
+import za.co.jumpingbean.jpaunit.exception.ParserException;
+import za.co.jumpingbean.jpaunit.loader.SaxHandler;
+import za.co.jumpingbean.jpaunit.test.model.NamedEntityWithNamedFields;
+
+import javax.persistence.EntityManager;
+import javax.persistence.Persistence;
+import javax.persistence.Query;
+import java.util.List;
+
+public class JpaLoaderAnnotatedFieldEntityTest {
+
+    private static EntityManager em;
+    private final String modelPackageName = "za.co.jumpingbean.jpaunit.test.model";
+
+    @BeforeClass
+    public static void beforeClass() {
+        em = Persistence.createEntityManagerFactory("jpaunittest").createEntityManager();
+    }
+
+    @Test
+    public void jpaMethodRobotEntityIdTest() throws ParserException {
+        JpaLoader loader = new JpaLoader();
+        loader.init("META-INF/namedrobotwithnamedfields.xml", modelPackageName, new SaxHandler(), em);
+        loader.load();
+
+        em.getTransaction().begin();
+        try {
+
+            Query qry = em.createQuery(
+                    "Select s from NamedEntityWithNamedFields s");
+            List<NamedEntityWithNamedFields> list = qry.getResultList();
+
+            Assert.assertEquals("Should have loaded 2 NamedEntityWithNamedFields objects", 2, list.size());
+        } finally {
+            em.getTransaction().commit();
+            loader.delete();
+        }
+    }
+}

--- a/src/test/java/za/co/jumpingbean/jpaunit/test/JpaLoaderAnnotatedMethodEntityTest.java
+++ b/src/test/java/za/co/jumpingbean/jpaunit/test/JpaLoaderAnnotatedMethodEntityTest.java
@@ -1,0 +1,89 @@
+package za.co.jumpingbean.jpaunit.test;
+
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import za.co.jumpingbean.jpaunit.JpaLoader;
+import za.co.jumpingbean.jpaunit.exception.ParserException;
+import za.co.jumpingbean.jpaunit.loader.SaxHandler;
+import za.co.jumpingbean.jpaunit.test.model.*;
+
+import javax.persistence.EntityManager;
+import javax.persistence.Persistence;
+import javax.persistence.Query;
+import java.util.List;
+
+public class JpaLoaderAnnotatedMethodEntityTest {
+
+    private static EntityManager em;
+    private final String modelPackageName = "za.co.jumpingbean.jpaunit.test.model";
+
+    @BeforeClass
+    public static void beforeClass() {
+        em = Persistence.createEntityManagerFactory("jpaunittest").createEntityManager();
+    }
+
+    @Test
+    public void jpaMethodCartoonEntityIdTest() throws ParserException {
+        JpaLoader loader = new JpaLoader();
+        loader.init("META-INF/namedcartoonwithnamedmethods.xml", modelPackageName, new SaxHandler(), em);
+        loader.load();
+
+        em.getTransaction().begin();
+        try {
+
+            Query qry = em.createQuery(
+                    "Select s from NamedEntityWithNamedMethods s");
+            List<NamedEntityWithNamedMethods> list = qry.getResultList();
+            Assert.assertEquals("Should have loaded 2 NamedEntityWithNamedMethods objects", 2, list.size());
+        } finally {
+            em.getTransaction().commit();
+            loader.delete();
+        }
+    }
+
+    @Test
+    public void jpaMethodStringEntityIdTest() throws ParserException {
+        JpaLoader loader = new JpaLoader();
+        loader.init("META-INF/methodstringidentity.xml", modelPackageName, new SaxHandler(), em);
+        loader.load();
+
+        em.getTransaction().begin();
+        try {
+
+            Query qry = em.createQuery(
+                    "Select s from MethodStringIdEntity s");
+            List<MethodStringIdEntity> list = qry.getResultList();
+            Assert.assertEquals("Should have loaded 3 MethodStringIdEntity objects", 3, list.size());
+        } finally {
+            em.getTransaction().commit();
+            loader.delete();
+        }
+    }
+
+    @Test
+    public void jpaMethodLongEntityTest() throws ParserException {
+        JpaLoader loader = new JpaLoader();
+        loader.init("META-INF/methodlongentity.xml", modelPackageName, new SaxHandler(), em);
+        loader.load();
+
+        em.getTransaction().begin();
+        try {
+            Query qry = em.createQuery(
+                    "Select s from MethodLongEntity s");
+            List<MethodLongEntity> list = qry.getResultList();
+            Assert.assertEquals("Failed to retrieve correct longValue", 3, list.size());
+            qry = em.createQuery("Select s from MethodLongEntity s where s.id =?");
+            //Check null insert on long number range exceeded
+            MethodLongEntity longE = new MethodLongEntity();
+            longE.setId(3L);
+            qry.setParameter(1, loader.lookupEntity(longE).getId());
+            MethodLongEntity longE2 = (MethodLongEntity) qry.getSingleResult();
+            Assert.assertNull(longE2.getLongValue());
+        } finally {
+            em.getTransaction().commit();
+            loader.delete();
+        }
+    }
+
+}

--- a/src/test/java/za/co/jumpingbean/jpaunit/test/JpaLoaderSimpleEntityTest.java
+++ b/src/test/java/za/co/jumpingbean/jpaunit/test/JpaLoaderSimpleEntityTest.java
@@ -81,6 +81,25 @@ public class JpaLoaderSimpleEntityTest {
     }
 
     @Test
+    public void jpaSimpleStringEntityIdTest() throws ParserException {
+        JpaLoader loader = new JpaLoader();
+        loader.init("META-INF/simplestringidentity.xml", modelPackageName, new SaxHandler(), em);
+        loader.load();
+        //em.clear();
+        em.getTransaction().begin();
+        try {
+
+            Query qry = em.createQuery(
+                    "Select s from SimpleStringIdEntity s");
+            List<SimpleStringEntity> list = qry.getResultList();
+            Assert.assertEquals("Should have loaded 3 SimpleStringIdEntity objects", 3, list.size());
+        } finally {
+            em.getTransaction().commit();
+            loader.delete();
+        }
+    }
+
+    @Test
     public void jpaSimpleDateEntityTest() throws ParserException {
         JpaLoader loader = new JpaLoader();
         loader.init("META-INF/simpledateentity.xml", modelPackageName, new SaxHandler(), em);
@@ -247,7 +266,7 @@ public class JpaLoaderSimpleEntityTest {
         try {
             Query qry = em.createQuery(
                     "Select s from SimpleLongEntity s");
-            List<SimpleStringEntity> list = qry.getResultList();
+            List<SimpleLongEntity> list = qry.getResultList();
             Assert.assertEquals("Failed to retrieve correct longValue", 3, list.size());
             qry = em.createQuery("Select s from SimpleLongEntity s where s.id =?");
             //Check null insert on long number range exceeded

--- a/src/test/java/za/co/jumpingbean/jpaunit/test/model/AnnotatedIdMethodEntity.java
+++ b/src/test/java/za/co/jumpingbean/jpaunit/test/model/AnnotatedIdMethodEntity.java
@@ -1,0 +1,18 @@
+package za.co.jumpingbean.jpaunit.test.model;
+
+import javax.persistence.Id;
+
+public class AnnotatedIdMethodEntity {
+
+    private int id;
+
+    @Id
+    int getId() {
+        return id;
+    }
+
+    void setId(int id) {
+         this.id = id;
+    }
+
+}

--- a/src/test/java/za/co/jumpingbean/jpaunit/test/model/MethodIntegerEntity.java
+++ b/src/test/java/za/co/jumpingbean/jpaunit/test/model/MethodIntegerEntity.java
@@ -1,0 +1,31 @@
+package za.co.jumpingbean.jpaunit.test.model;
+
+import javax.persistence.*;
+
+@Entity
+public class MethodIntegerEntity {
+
+    private int id;
+
+    private Integer integerValue;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.TABLE)
+    @Column(name = "id")
+    public int getId() {
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    public Integer getIntegerValue() {
+        return integerValue;
+    }
+
+    public void setIntegerValue(Integer integer) {
+        this.integerValue = integer;
+    }
+
+}

--- a/src/test/java/za/co/jumpingbean/jpaunit/test/model/MethodLongEntity.java
+++ b/src/test/java/za/co/jumpingbean/jpaunit/test/model/MethodLongEntity.java
@@ -1,0 +1,30 @@
+package za.co.jumpingbean.jpaunit.test.model;
+
+import javax.persistence.*;
+
+@Entity
+public class MethodLongEntity {
+
+    private Long id;
+
+    private Long longValue;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.TABLE)
+    @Column(name = "id")
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Long getLongValue() {
+        return longValue;
+    }
+
+    public void setLongValue(Long longValue) {
+        this.longValue = longValue;
+    }
+}

--- a/src/test/java/za/co/jumpingbean/jpaunit/test/model/MethodStringIdEntity.java
+++ b/src/test/java/za/co/jumpingbean/jpaunit/test/model/MethodStringIdEntity.java
@@ -1,0 +1,37 @@
+package za.co.jumpingbean.jpaunit.test.model;
+
+import org.hibernate.annotations.GenericGenerator;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+
+@Entity
+public class MethodStringIdEntity {
+
+    public String name;
+
+    public String stringValue;
+
+    @Id
+    @GeneratedValue(generator = "uuid")
+    @GenericGenerator(name = "uuid", strategy = "uuid2")
+    @Column(name = "name", nullable = false)
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getStringValue() {
+        return stringValue;
+    }
+
+    public void setStringValue(String stringValue) {
+        this.stringValue = stringValue;
+    }
+
+}

--- a/src/test/java/za/co/jumpingbean/jpaunit/test/model/NamedEntityWithNamedFields.java
+++ b/src/test/java/za/co/jumpingbean/jpaunit/test/model/NamedEntityWithNamedFields.java
@@ -1,0 +1,35 @@
+package za.co.jumpingbean.jpaunit.test.model;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+@Entity
+@Table(name="ROBOT")
+public class NamedEntityWithNamedFields {
+
+    @Id
+    @Column( name = "name" )
+    String robotLeader;
+
+    @Column( name = "team_name" )
+    String teamName;
+
+
+    public String getRobotLeader() {
+        return robotLeader;
+    }
+
+    public void setRobotLeader(String robotLeader) {
+        this.robotLeader = robotLeader;
+    }
+
+    public String getTeamName() {
+        return teamName;
+    }
+
+    public void setTeamName(String teamName) {
+        this.teamName = teamName;
+    }
+}

--- a/src/test/java/za/co/jumpingbean/jpaunit/test/model/NamedEntityWithNamedMethods.java
+++ b/src/test/java/za/co/jumpingbean/jpaunit/test/model/NamedEntityWithNamedMethods.java
@@ -1,0 +1,33 @@
+package za.co.jumpingbean.jpaunit.test.model;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+@Entity
+@Table(name="CARTOON")
+public class NamedEntityWithNamedMethods {
+
+    String cartoon;
+    String leadCharacter;
+
+    @Id
+    @Column( name = "cartoon" )
+    public String getCartoon() {
+        return cartoon;
+    }
+
+    public void setCartoon(String cartoon) {
+        this.cartoon = cartoon;
+    }
+
+    @Column( name = "lead_character" )
+    public String getLeadCharacter() {
+        return leadCharacter;
+    }
+
+    public void setLeadCharacter(String leadCharacter) {
+        this.leadCharacter = leadCharacter;
+    }
+}

--- a/src/test/java/za/co/jumpingbean/jpaunit/test/model/SimpleStringIdEntity.java
+++ b/src/test/java/za/co/jumpingbean/jpaunit/test/model/SimpleStringIdEntity.java
@@ -1,0 +1,34 @@
+package za.co.jumpingbean.jpaunit.test.model;
+
+import org.hibernate.annotations.GenericGenerator;
+
+import javax.persistence.*;
+
+@Entity
+public class SimpleStringIdEntity {
+
+    @Id
+    @GeneratedValue(generator = "uuid")
+    @GenericGenerator(name = "uuid", strategy = "uuid2")
+    @Column(name = "id", nullable = false)
+    public String id;
+
+    public String stringValue;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getStringValue() {
+        return stringValue;
+    }
+
+    public void setStringValue(String stringValue) {
+        this.stringValue = stringValue;
+    }
+
+}

--- a/src/test/resources/META-INF/methodintegerentity.xml
+++ b/src/test/resources/META-INF/methodintegerentity.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dataset>
+    <MethodIntegerEntity id="1" integerValue="1" />
+    <MethodIntegerEntity id="2" integerValue="-200" />
+    <MethodIntegerEntity id="3" integerValue="-2147483649" />
+</dataset>

--- a/src/test/resources/META-INF/methodlongentity.xml
+++ b/src/test/resources/META-INF/methodlongentity.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dataset>
+    <MethodLongEntity id="1" longValue="1" />
+    <MethodLongEntity id="2" longValue="-20000000000000" />
+    <MethodLongEntity id="3" longValue="9223372036854775808" />
+</dataset>

--- a/src/test/resources/META-INF/methodstringidentity.xml
+++ b/src/test/resources/META-INF/methodstringidentity.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dataset>
+    <MethodStringIdEntity name="one" stringValue="test1" />
+    <MethodStringIdEntity name="two" stringValue="test2" />
+    <MethodStringIdEntity name="three" stringValue="test3" />
+</dataset>

--- a/src/test/resources/META-INF/namedcartoonwithnamedmethods.xml
+++ b/src/test/resources/META-INF/namedcartoonwithnamedmethods.xml
@@ -1,0 +1,5 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<dataset>
+    <CARTOON cartoon="Loony Toons" lead_character="Bugs Bunny" />
+    <CARTOON cartoon="Duck Tales" lead_character="Duck Triplets" />
+</dataset>

--- a/src/test/resources/META-INF/namedrobotwithnamedfields.xml
+++ b/src/test/resources/META-INF/namedrobotwithnamedfields.xml
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<dataset>
+    <!-- Last_modify_dt as null -->
+    <ROBOT name="Optimus Prime" team_name="Autobots" />
+    <ROBOT name="Megatron" team_name="Decepticons" />
+</dataset>

--- a/src/test/resources/META-INF/simplestringidentity.xml
+++ b/src/test/resources/META-INF/simplestringidentity.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dataset>
+    <SimpleStringIdEntity id="one" stringValue="test1" />
+    <SimpleStringIdEntity id="two" stringValue="test2" />
+    <SimpleStringIdEntity id="three" stringValue="test3" />
+</dataset>


### PR DESCRIPTION
int getId() and setId(int) methods no longer required on entity objects
 @Id and @Column JPA Annotations on methods honored
 Column names referenced in DBUnit XML via @Column(name=) now honored  **casing must match**
 @Table(name=) can now be used as XML Element names **casing must match**
 Updated version in POM file to 0.2 since functionality has been enhanced
